### PR TITLE
Host instance resolution improvements

### DIFF
--- a/Pract/Types.lua
+++ b/Pract/Types.lua
@@ -102,7 +102,11 @@ export type ContextProvider = {
 	unprovide: (name: string) -> (),
 }
 export type SiblingClusterCache = {
-	lastInstance: Instance?,
+	currentSiblingIdx: number,
+	providedInstanceHostSet: {[Instance]: boolean},
+	lastProvidedInstance: Instance?,
+	idxToProvidedInstanceHost: {[number]: Instance},
+	idxToConsumedInstanceHost: {[number]: Instance},
 }
 export type HostContext = {	-- Immutable type used as an object reference passed down in trees; the
 							-- purpose of grouping these together is because typically components

--- a/Pract/Types.lua
+++ b/Pract/Types.lua
@@ -101,6 +101,9 @@ export type ContextProvider = {
 	provide: (name: string, object: any?) -> (),
 	unprovide: (name: string) -> (),
 }
+export type SiblingClusterCache = {
+	lastInstance: Instance?,
+}
 export type HostContext = {	-- Immutable type used as an object reference passed down in trees; the
 							-- purpose of grouping these together is because typically components
 							-- share the same host and context information except in special cases.
@@ -108,6 +111,7 @@ export type HostContext = {	-- Immutable type used as an object reference passed
 	instance: Instance?,
 	childKey: string?,
 	providers: {ContextProvider},
+	siblingClusterCache: SiblingClusterCache?,
 }
 export type VirtualNode = {
 	[any]: any,
@@ -132,7 +136,8 @@ export type Reconciler = {
 	createHost: (
 		instance: Instance?,
 		key: string?,
-		providers: {ContextProvider}
+		providers: {ContextProvider},
+		siblingClusterCache: SiblingClusterCache?
 	) -> HostContext
 }
 

--- a/Pract/createReconciler.lua
+++ b/Pract/createReconciler.lua
@@ -581,8 +581,11 @@ local function createReconciler(): Types.Reconciler
 	local function getIndexedChildFromHost(hostContext: Types.HostContext): Instance?
 		local siblingClusterCache = hostContext.siblingClusterCache
 		if siblingClusterCache then
-			local lastInstance = siblingClusterCache.lastInstance
+			local lastInstance = siblingClusterCache.lastProvidedInstance
 			if lastInstance then
+				siblingClusterCache.idxToConsumedInstanceHost[
+					siblingClusterCache.currentSiblingIdx
+				] = lastInstance
 				return lastInstance
 			end
 		end
@@ -660,8 +663,11 @@ local function createReconciler(): Types.Reconciler
 					
 					local child: any
 					if siblingClusterCache then
-						local lastInstance = siblingClusterCache.lastInstance
+						local lastInstance = siblingClusterCache.lastProvidedInstance
 						if lastInstance then
+							siblingClusterCache.idxToConsumedInstanceHost[
+								siblingClusterCache.currentSiblingIdx
+							] = lastInstance
 							child = lastInstance
 							break
 						end
@@ -895,17 +901,37 @@ local function createReconciler(): Types.Reconciler
 		end
 		
 		updateByElementKind[ElementKinds.SiblingCluster] = function(virtualNode, newElement)
+			local siblingHost = virtualNode._hostContext
+			local siblingClusterCache = siblingHost.siblingClusterCache :: Types.SiblingClusterCache
 			local siblings = virtualNode._siblings
 			local elements = newElement.elements
 			local nextSiblings = table.create(#elements)
+
+			local idxToConsumedInstanceHost = siblingClusterCache.idxToConsumedInstanceHost
+			local providedInstanceHostSet = siblingClusterCache.providedInstanceHostSet
 			for i = 1, #siblings do
-				table.insert(nextSiblings, updateVirtualNode(siblings[i], elements[i]))
+				siblingClusterCache.currentSiblingIdx = i
+				-- We should re-mount a component later in a sibling cluster iff it relies on a
+				-- previous sibling's created instance!
+				local consumedInstance = idxToConsumedInstanceHost[i]
+				if consumedInstance and not providedInstanceHostSet[consumedInstance] then
+					table.insert(nextSiblings, replaceVirtualNode(
+						siblings[i],
+						elements[i]
+					))
+				else
+					table.insert(nextSiblings, updateVirtualNode(
+						siblings[i],
+						elements[i])
+					)
+				end
 			end
 			
 			for i = #siblings + 1, #elements do
+				siblingClusterCache.currentSiblingIdx = i
 				table.insert(nextSiblings, mountVirtualNode(
 					elements[i],
-					virtualNode._hostContext
+					siblingHost
 				))
 			end
 			
@@ -1089,7 +1115,11 @@ local function createReconciler(): Types.Reconciler
 
 			local siblingClusterCache = hostContext.siblingClusterCache
 			if siblingClusterCache then
-				siblingClusterCache.lastInstance = instance
+				siblingClusterCache.providedInstanceHostSet[instance] = true
+				siblingClusterCache.idxToProvidedInstanceHost[
+					siblingClusterCache.currentSiblingIdx
+				] = instance
+				siblingClusterCache.lastProvidedInstance = instance
 			end
 		end
 		mountByElementKind[ElementKinds.CreateInstance] = function(virtualNode)
@@ -1114,10 +1144,14 @@ local function createReconciler(): Types.Reconciler
 			
 			instance.Parent = hostContext.instance
 			virtualNode._instance = instance
-			
+
 			local siblingClusterCache = hostContext.siblingClusterCache
 			if siblingClusterCache then
-				siblingClusterCache.lastInstance = instance
+				siblingClusterCache.providedInstanceHostSet[instance] = true
+				siblingClusterCache.idxToProvidedInstanceHost[
+					siblingClusterCache.currentSiblingIdx
+				] = instance
+				siblingClusterCache.lastProvidedInstance = instance
 			end
 		end
 		mountByElementKind[ElementKinds.Index] = function(virtualNode)
@@ -1414,19 +1448,25 @@ local function createReconciler(): Types.Reconciler
 		
 		mountByElementKind[ElementKinds.SiblingCluster] = function(virtualNode)
 			local providedHost = virtualNode._hostContext
+			local siblingClusterCache = {
+				currentSiblingIdx = 1,
+				providedInstanceHostSet = {},
+				idxToProvidedInstanceHost = {},
+				idxToConsumedInstanceHost = {},
+				lastProvidedInstance = nil,
+			}
 			local siblingHost = createHost(
 				providedHost.instance,
 				providedHost.childKey,
 				providedHost.providers,
-				{
-					lastInstance = nil,
-				}
+				siblingClusterCache
 			)
-			siblingHost.isSiblingCluster = true
 			virtualNode._hostContext = siblingHost
 			local elements = virtualNode._currentElement.elements
 			local siblings = table.create(#elements)
+
 			for i = 1, #elements do
+				siblingClusterCache.currentSiblingIdx = i
 				table.insert(siblings, mountVirtualNode(
 					elements[i],
 					siblingHost
@@ -1466,6 +1506,66 @@ local function createReconciler(): Types.Reconciler
 	end
 	
 	do
+		--[[
+			This utility should thoroughly clear cached values within a sibling cluster, if one
+			exists in the host context.
+
+			The issue with behavior consistency in sibling clusters is in situations like the
+			following example:
+
+				1. Mount a pract tree with a Pract.combine element, containing a Pract.stamp and
+				Pract.decorate component.
+
+					When mounted, the stamp element will stamp a template instance, and via the
+					sibling cluster cache, the decorate element will decorate the previously stamped
+					instance in this cluster.
+				
+				2. Update the pract tree with a similar Pract.combine element—the only difference
+				being that the stamp element has changed its template!
+
+					When updated, the first stamp element in this sibling cluster must be replaced--
+					that is, it should be unmounted then mounted again with the new template.
+
+					The issue here is that the next Pract.decorate element in this cluster DEPENDS
+					on the host created via the previous stamp element! This means it must be
+					replaced (unmounted then mounted again) as well! This is handled in the sibling
+					cluster update code.
+			
+			The current solution to this issue uses a cache within the host context itself; this
+			implementation is a little obscure and prone to memory leaks if it isn't designed with
+			airtight code. In addition, adding element types to Pract would require taking sibling
+			cluster behavior in the future. Unit tests can alleviate some of these issues, but
+			the combinatorial possibilities/proliferation of element types could make this hard to
+			thoroughly unit test with newly implemented element types. In addition, the sibling
+			cluster needs to propogate into certain nested hosts or elements using the same host.
+		]]
+		local function unmountSiblingClusterHost(
+			hostContext: Types.HostContext,
+			instance: Instance
+		)
+			local siblingClusterCache = hostContext.siblingClusterCache
+			if siblingClusterCache then
+				local currentSiblingIdx = siblingClusterCache.currentSiblingIdx
+				local idxToProvidedInstanceHost = siblingClusterCache.idxToProvidedInstanceHost
+				local idxToConsumedInstanceHost = siblingClusterCache.idxToConsumedInstanceHost
+				local providedInstanceHostSet = siblingClusterCache.providedInstanceHostSet
+				providedInstanceHostSet[instance] = nil
+				idxToProvidedInstanceHost[currentSiblingIdx] = nil
+				idxToConsumedInstanceHost[currentSiblingIdx] = nil
+				if siblingClusterCache.lastProvidedInstance == instance then
+					local maxIdx, maxInst = next(idxToProvidedInstanceHost)
+					for idx, inst in pairs(idxToProvidedInstanceHost) do
+						if idx > maxIdx then
+							maxIdx = idx
+							maxInst = inst
+						end
+					end
+
+					siblingClusterCache.lastProvidedInstance = maxInst
+				end
+			end
+		end
+
 		local unmountByElementKind = {} :: {
 			[Types.Symbol]: (virtualNode: Types.VirtualNode) -> ()
 		}
@@ -1478,12 +1578,16 @@ local function createReconciler(): Types.Reconciler
 		unmountByElementKind[ElementKinds.CreateInstance] = function(virtualNode)
 			unmountDecorationProps(virtualNode, true)
 			unmountChildren(virtualNode)
-			virtualNode._instance:Destroy()
+			local instance = virtualNode._instance
+			unmountSiblingClusterHost(virtualNode._hostContext, instance)
+			instance:Destroy()
 		end
 		unmountByElementKind[ElementKinds.Stamp] = function(virtualNode)
 			unmountDecorationProps(virtualNode, true)
 			unmountChildren(virtualNode)
-			virtualNode._instance:Destroy()
+			local instance = virtualNode._instance
+			unmountSiblingClusterHost(virtualNode._hostContext, instance)
+			instance:Destroy()
 		end
 		unmountByElementKind[ElementKinds.Portal] = function(virtualNode)
 			unmountChildren(virtualNode)
@@ -1519,8 +1623,11 @@ local function createReconciler(): Types.Reconciler
 			unmountVirtualNode(virtualNode._child)
 		end
 		unmountByElementKind[ElementKinds.SiblingCluster] = function(virtualNode)
+			local siblingHost = virtualNode._hostContext
+			local siblingClusterCache = siblingHost.siblingClusterCache :: Types.SiblingClusterCache
 			local siblings = virtualNode._siblings
 			for i = 1, #siblings do
+				siblingClusterCache.currentSiblingIdx = i
 				unmountVirtualNode(siblings[i])
 			end
 		end

--- a/Pract/init.lua
+++ b/Pract/init.lua
@@ -5,7 +5,7 @@
 -- https://ambers-careware.github.io/pract/
 
 local Pract = {}
-Pract._VERSION = '0.9.8'
+Pract._VERSION = '0.9.9'
 
 local Types = require(script.Types)
 local PractGlobalSystems = require(script.PractGlobalSystems)

--- a/TestPract/specs/createReconciler.lua
+++ b/TestPract/specs/createReconciler.lua
@@ -116,7 +116,7 @@ local spec: Types.Spec = function(practModule, describe)
 
             local tree = reconciler.mountVirtualTree(
                 Pract.combine(
-                    Pract.stamp(template1, {Name = "FromTemplate1"}),
+                    Pract.stamp(template1),
                     Pract.decorate({
                         [Pract.Attributes] = {
                             WasDecorated = true,
@@ -141,7 +141,7 @@ local spec: Types.Spec = function(practModule, describe)
             reconciler.updateVirtualTree(
                 tree,
                 Pract.combine(
-                    Pract.stamp(template2, {Name = "FromTemplate2"}),
+                    Pract.stamp(template2),
                     Pract.decorate({
                         [Pract.Attributes] = {
                             WasDecorated = true,

--- a/TestPract/specs/createReconciler.lua
+++ b/TestPract/specs/createReconciler.lua
@@ -31,7 +31,7 @@ local spec: Types.Spec = function(practModule, describe)
     describe('createHost', function(it)
         it('creates a host with no instance, no key, and empty providers', function(expect)
             local defaultProviders = {}
-            defaultHost = reconciler.createHost(nil, nil, defaultProviders)
+            defaultHost = reconciler.createHost(nil, nil, defaultProviders, nil)
             expect.equal(nil, defaultHost.instance)
             expect.equal(nil, defaultHost.childKey)
             expect.equal(defaultProviders, defaultHost.providers)


### PR DESCRIPTION
This tentative release fixes a crucial bug with `Pract.stamp`, in which an updated element won't cause the current mounted element to unmount if the stamped template changes.

In addition to this, the host instance resolution behavior is improved with `Pract.combine`—namely, when combining a `Pract.decorate` element or other decorator/indexing element with a `Pract.stamp`/`Pract.create` element, the last instance generated in the combine expression will be used as the host for further decorating elements.

This means the actual behavior of `Pract.combine` should match what you would intuitively expect it to do. Pract should correctly unmount and re-mount elements in a `Pract.combine` cluster when necessary.

The implementation of this is a little complicated, and has some unit tests in place to ensure the correct behavior. In the future, perhaps this can be refactored.

I am currently a bit busy working my own Roblox game, so reconciler test coverage is still incomplete. The bugs fixed in this PR now have unit tests.