### PR TITLE
Improve and Document `Pract.combine` position-based behavior

### DIFF
--- a/Pract/Types.lua
+++ b/Pract/Types.lua
@@ -102,11 +102,8 @@ export type ContextProvider = {
 	unprovide: (name: string) -> (),
 }
 export type SiblingClusterCache = {
-	currentSiblingIdx: number,
-	providedInstanceHostSet: {[Instance]: boolean},
 	lastProvidedInstance: Instance?,
-	idxToProvidedInstanceHost: {[number]: Instance},
-	idxToConsumedInstanceHost: {[number]: Instance},
+	lastUpdateConsumedInstances: {[number]: Instance?},
 }
 export type HostContext = {	-- Immutable type used as an object reference passed down in trees; the
 							-- purpose of grouping these together is because typically components

--- a/Pract/createReconciler.lua
+++ b/Pract/createReconciler.lua
@@ -573,7 +573,7 @@ local function createReconciler(): Types.Reconciler
 			end
 			
 			for i = 1, #toCallWithHostInstance do
-				task.defer(toCallWithHostInstance[i], lastUpdateInstance)
+				task.spawn(toCallWithHostInstance[i], lastUpdateInstance)
 			end
 		end
 	end
@@ -791,7 +791,7 @@ local function createReconciler(): Types.Reconciler
 			if siblingClusterCache then
 				siblingClusterCache.lastProvidedInstance = virtualNode._instance
 			end
-			
+
 			local success, err: string? = pcall(
 				updateDecorationProps,
 				virtualNode,
@@ -1634,20 +1634,20 @@ local function createReconciler(): Types.Reconciler
 
 		unmountByElementKind[ElementKinds.OnChild] = unmountOnChildNode
 		unmountByElementKind[ElementKinds.Decorate] = function(virtualNode)
-			unmountDecorationProps(virtualNode, false)
 			unmountChildren(virtualNode)
+			unmountDecorationProps(virtualNode, false)
 		end
 		unmountByElementKind[ElementKinds.CreateInstance] = function(virtualNode)
-			unmountDecorationProps(virtualNode, true)
 			unmountChildren(virtualNode)
 			local instance = virtualNode._instance
 			instance:Destroy()
+			unmountDecorationProps(virtualNode, true)
 		end
 		unmountByElementKind[ElementKinds.Stamp] = function(virtualNode)
-			unmountDecorationProps(virtualNode, true)
 			unmountChildren(virtualNode)
 			local instance = virtualNode._instance
 			instance:Destroy()
+			unmountDecorationProps(virtualNode, true)
 		end
 		unmountByElementKind[ElementKinds.Portal] = function(virtualNode)
 			unmountChildren(virtualNode)

--- a/Pract/createReconciler.lua
+++ b/Pract/createReconciler.lua
@@ -489,6 +489,8 @@ local function createReconciler(): Types.Reconciler
 				end
 			)
 		end
+
+		updateLifecycleProps(props, instance)
 	end
 	
 	local function unmountDecorationProps(
@@ -942,7 +944,7 @@ local function createReconciler(): Types.Reconciler
 			siblingClusterCache.lastUpdateConsumedInstances = nextConsumedInstances
 
 			-- First pass: See which elements are incompatible by type
-			local shouldReplacePastIndex = nil
+			local shouldReplacePastIndex = #siblings + 1
 			local shouldUnmountIndicesInFirstPass = {}
 			for i = 1, #siblings do
 				local element = nonNilElements[i]
@@ -997,26 +999,22 @@ local function createReconciler(): Types.Reconciler
 			end
 			
 			-- Third pass: Unmount nodes from [shouldReplacePastIndex, #siblings]
-			if shouldReplacePastIndex then
-				for i = shouldReplacePastIndex, #siblings do
-					if not shouldUnmountIndicesInFirstPass[i] then
-						unmountVirtualNode(siblings[i])
-					end
+			for i = shouldReplacePastIndex, #siblings do
+				if not shouldUnmountIndicesInFirstPass[i] then
+					unmountVirtualNode(siblings[i])
 				end
 			end
 			
 			-- Mount nodes from [shouldReplacePastIndex, #siblings]
-			if shouldReplacePastIndex then
-				for i = shouldReplacePastIndex + 1, #siblings do
-					lastProvidedInstance = siblingClusterCache.lastProvidedInstance
-					nextConsumedInstances[i] = lastProvidedInstance
-					local node = mountVirtualNode(
-						nonNilElements[i],
-						siblingHost
-					)
-					if node then
-						table.insert(nextSiblings, node)
-					end
+			for i = shouldReplacePastIndex, #siblings do
+				lastProvidedInstance = siblingClusterCache.lastProvidedInstance
+				nextConsumedInstances[i] = lastProvidedInstance
+				local node = mountVirtualNode(
+					nonNilElements[i],
+					siblingHost
+				)
+				if node then
+					table.insert(nextSiblings, node)
 				end
 			end
 

--- a/Pract/createReconciler.lua
+++ b/Pract/createReconciler.lua
@@ -583,9 +583,6 @@ local function createReconciler(): Types.Reconciler
 		if siblingClusterCache then
 			local lastInstance = siblingClusterCache.lastProvidedInstance
 			if lastInstance then
-				siblingClusterCache.idxToConsumedInstanceHost[
-					siblingClusterCache.currentSiblingIdx
-				] = lastInstance
 				return lastInstance
 			end
 		end
@@ -672,7 +669,7 @@ local function createReconciler(): Types.Reconciler
 							threadResumeEvent:Fire(nil)
 						end
 					end)
-					local child = threadResumeEvent:Wait()
+					local child = threadResumeEvent.Event:Wait()
 					didResume = true
 					childAddedConn:Disconnect()
 					threadResumeEvent:Destroy()
@@ -696,6 +693,45 @@ local function createReconciler(): Types.Reconciler
 					end
 				until false
 			end)
+		end
+	end
+
+	local nodeCanUpdateWithElement: (
+		virtualNode: Types.VirtualNode,
+		newElement: Types.Element
+	) -> boolean
+	do
+		local nodeCanUpdateWithElementByKind = {} :: {
+			[Types.Symbol]: (virtualNode: Types.VirtualNode, newElement: Types.Element) -> boolean
+		}
+		nodeCanUpdateWithElementByKind[ElementKinds.Stamp] = function(virtualNode, newElement)
+			return virtualNode._currentElement.template == newElement.template
+		end
+		nodeCanUpdateWithElementByKind[ElementKinds.Portal] = function(virtualNode, newElement)
+			return virtualNode._currentElement.hostParent == newElement.hostParent
+		end
+		nodeCanUpdateWithElementByKind[ElementKinds.RenderComponent] = function(virtualNode, newElement)
+			return virtualNode._currentElement.component == newElement.component
+		end
+		nodeCanUpdateWithElementByKind[ElementKinds.SignalComponent] = function(virtualNode, newElement)
+			return virtualNode._currentElement.signal == newElement.signal
+		end
+			
+		setmetatable(nodeCanUpdateWithElementByKind, {
+			__index = function()
+				return function() return true end
+			end
+		})
+
+		function nodeCanUpdateWithElement(virtualNode, newElement)
+			local currentElement = virtualNode._currentElement
+			
+			local kind = (newElement :: any)[Symbol_ElementKind]
+			if currentElement[Symbol_ElementKind] == kind then
+				return nodeCanUpdateWithElementByKind[kind](virtualNode, newElement :: any)
+			else
+				return false
+			end
 		end
 	end
 	
@@ -751,9 +787,11 @@ local function createReconciler(): Types.Reconciler
 		end
 		
 		updateByElementKind[ElementKinds.Stamp] = function(virtualNode, newElement)
-			if virtualNode._currentElement.template ~= newElement.template then
-				return replaceVirtualNode(virtualNode, newElement)
+			local siblingClusterCache = virtualNode._hostContext.siblingClusterCache
+			if siblingClusterCache then
+				siblingClusterCache.lastProvidedInstance = virtualNode._instance
 			end
+			
 			local success, err: string? = pcall(
 				updateDecorationProps,
 				virtualNode,
@@ -772,6 +810,11 @@ local function createReconciler(): Types.Reconciler
 		end
 		
 		updateByElementKind[ElementKinds.CreateInstance] = function(virtualNode, newElement)
+			local siblingClusterCache = virtualNode._hostContext.siblingClusterCache
+			if siblingClusterCache then
+				siblingClusterCache.lastProvidedInstance = virtualNode._instance
+			end
+
 			local success, err: string? = pcall(
 				updateDecorationProps,
 				virtualNode,
@@ -790,21 +833,12 @@ local function createReconciler(): Types.Reconciler
 		end
 		
 		updateByElementKind[ElementKinds.Portal] = function(virtualNode, newElement)
-			local element = virtualNode._currentElement
-			if element.hostParent ~= newElement.hostParent then
-				return replaceVirtualNode(virtualNode, newElement)
-			end
 			updateChildren(virtualNode, newElement.hostParent, newElement.children)
 			
 			return virtualNode
 		end
 		
 		updateByElementKind[ElementKinds.RenderComponent] = function(virtualNode, newElement)
-			local saveElement = virtualNode._currentElement
-			if saveElement.component ~= newElement.component then
-				return replaceVirtualNode(virtualNode, newElement)
-			end
-			
 			virtualNode._child = updateVirtualNode(
 				virtualNode._child,
 				newElement.component(newElement.props)
@@ -867,10 +901,6 @@ local function createReconciler(): Types.Reconciler
 		end
 		
 		updateByElementKind[ElementKinds.SignalComponent] = function(virtualNode, newElement)
-			if virtualNode._currentElement.signal ~= newElement.signal then
-				return replaceVirtualNode(virtualNode, newElement)
-			end
-			
 			virtualNode._child = updateVirtualNode(
 				virtualNode._child,
 				newElement.render(newElement.props)
@@ -898,46 +928,111 @@ local function createReconciler(): Types.Reconciler
 		end
 		
 		updateByElementKind[ElementKinds.SiblingCluster] = function(virtualNode, newElement)
-			local siblingHost = virtualNode._hostContext
+			local parentHost = virtualNode._hostContext
+			local siblingHost = virtualNode._siblingHost
 			local siblingClusterCache = siblingHost.siblingClusterCache :: Types.SiblingClusterCache
 			local siblings = virtualNode._siblings
 			local elements = newElement.elements
+
 			local nonNilElements = table.create(#elements)
 			for i = 1, #elements do
-				if elements[i] then
+				if typeof(elements[i]) == "table" then
 					table.insert(nonNilElements, elements[i])
 				end
 			end
+
+			-- Save/replace cache
+			local saveConsumedInstances = siblingClusterCache.lastUpdateConsumedInstances
+			local nextConsumedInstances = table.create(#nonNilElements)
+			local lastProvidedInstance = nil
+			local parentSiblingClusterCache = parentHost.siblingClusterCache
+			if parentSiblingClusterCache then
+				lastProvidedInstance = parentSiblingClusterCache.lastProvidedInstance
+			end
+			siblingClusterCache.lastProvidedInstance = lastProvidedInstance
+			siblingClusterCache.lastUpdateConsumedInstances = nextConsumedInstances
+
+			-- First pass: See which elements are incompatible by type
+			local shouldReplacePastIndex = nil
+			local shouldUnmountIndicesInFirstPass = {}
+			for i = 1, #siblings do
+				local element = nonNilElements[i]
+				if not (element and nodeCanUpdateWithElement(siblings[i], element :: any)) then
+					shouldUnmountIndicesInFirstPass[i] = true
+					shouldReplacePastIndex = shouldReplacePastIndex or i
+				else
+					shouldUnmountIndicesInFirstPass[i] = false
+				end
+			end
+
+			-- We want to unmount existing components before we mount new ones!
+			for i = 1, #siblings do
+				if shouldUnmountIndicesInFirstPass[i] then
+					unmountVirtualNode(siblings[i])
+				end
+			end
+
 			local nextSiblings = table.create(#nonNilElements)
 
-			local idxToConsumedInstanceHost = siblingClusterCache.idxToConsumedInstanceHost
-			local providedInstanceHostSet = siblingClusterCache.providedInstanceHostSet
-			for i = 1, #siblings do
-				siblingClusterCache.currentSiblingIdx = i
-				-- We should re-mount a component later in a sibling cluster iff it relies on a
-				-- previous sibling's created instance!
-				local consumedInstance = idxToConsumedInstanceHost[i]
-				if consumedInstance and not providedInstanceHostSet[consumedInstance] then
-					local newNode = replaceVirtualNode(
-						siblings[i],
-						nonNilElements[i]
+			-- Second pass: Mount nodes until we find a differing provided instance
+			for i = 1, math.min(shouldReplacePastIndex, #siblings) do
+				lastProvidedInstance = siblingClusterCache.lastProvidedInstance
+				nextConsumedInstances[i] = lastProvidedInstance
+				if shouldUnmountIndicesInFirstPass[i] then
+					-- Create a new virtual node at this index now that we have unmounted all
+					-- previous incompatible nodes.
+					local node = mountVirtualNode(
+						elements[i],
+						siblingHost
 					)
-					if newNode then
-						table.insert(nextSiblings, newNode)
+					if node then
+						table.insert(nextSiblings, node)
 					end
 				else
-					local node = updateVirtualNode(
-						siblings[i],
-						nonNilElements[i]
+					-- We should re-mount a component later in a sibling cluster iff it relies on a
+					-- previous sibling's created instance!
+					local consumedInstance = saveConsumedInstances[i]
+					if consumedInstance ~= lastProvidedInstance then
+						shouldReplacePastIndex = i
+						break
+					else
+						local node = updateVirtualNode(
+							siblings[i],
+							nonNilElements[i]
+						)
+						if node then
+							table.insert(nextSiblings, node)
+						end
+					end
+				end
+			end
+			
+			-- Third pass: Unmount nodes from [shouldReplacePastIndex, #siblings]
+			if shouldReplacePastIndex then
+				for i = shouldReplacePastIndex, #siblings do
+					if not shouldUnmountIndicesInFirstPass[i] then
+						unmountVirtualNode(siblings[i])
+					end
+				end
+			end
+			
+			-- Mount nodes from [shouldReplacePastIndex, #siblings]
+			if shouldReplacePastIndex then
+				for i = shouldReplacePastIndex + 1, #siblings do
+					lastProvidedInstance = siblingClusterCache.lastProvidedInstance
+					nextConsumedInstances[i] = lastProvidedInstance
+					local node = mountVirtualNode(
+						nonNilElements[i],
+						siblingHost
 					)
 					if node then
 						table.insert(nextSiblings, node)
 					end
 				end
 			end
-			
+
+			-- Fourth pass: mount nodes from (#siblings, #nonNilElements]
 			for i = #siblings + 1, #nonNilElements do
-				siblingClusterCache.currentSiblingIdx = i
 				local node = mountVirtualNode(
 					nonNilElements[i],
 					siblingHost
@@ -948,6 +1043,14 @@ local function createReconciler(): Types.Reconciler
 			end
 			
 			virtualNode._siblings = nextSiblings
+
+			-- Propogate the last provided instance to the parent
+			if parentSiblingClusterCache then
+				local instanceToProvide = siblingClusterCache.lastProvidedInstance
+				if instanceToProvide then
+					parentSiblingClusterCache.lastProvidedInstance = instanceToProvide
+				end
+			end
 			return virtualNode
 		end
 
@@ -971,13 +1074,14 @@ local function createReconciler(): Types.Reconciler
 			end
 			
 			local kind = (newElement :: any)[Symbol_ElementKind]
-			if currentElement[Symbol_ElementKind] == kind then
+			if nodeCanUpdateWithElement(virtualNode, newElement :: any) then
 				local nextNode = updateByElementKind[kind](virtualNode, newElement :: any)
 				if nextNode then
 					nextNode._currentElement = newElement :: any
 				end
 				return nextNode
 			else
+				-- Special case — replace our node with a resolved node
 				if currentElement[Symbol_ElementKind] == ElementKinds.OnChild then
 					if virtualNode._resolved then
 						-- Place in child node if it was latently resolved and mounted
@@ -1127,10 +1231,6 @@ local function createReconciler(): Types.Reconciler
 
 			local siblingClusterCache = hostContext.siblingClusterCache
 			if siblingClusterCache then
-				siblingClusterCache.providedInstanceHostSet[instance] = true
-				siblingClusterCache.idxToProvidedInstanceHost[
-					siblingClusterCache.currentSiblingIdx
-				] = instance
 				siblingClusterCache.lastProvidedInstance = instance
 			end
 		end
@@ -1159,10 +1259,6 @@ local function createReconciler(): Types.Reconciler
 
 			local siblingClusterCache = hostContext.siblingClusterCache
 			if siblingClusterCache then
-				siblingClusterCache.providedInstanceHostSet[instance] = true
-				siblingClusterCache.idxToProvidedInstanceHost[
-					siblingClusterCache.currentSiblingIdx
-				] = instance
 				siblingClusterCache.lastProvidedInstance = instance
 			end
 		end
@@ -1269,7 +1365,7 @@ local function createReconciler(): Types.Reconciler
 			
 			local didMount = closure.didMount
 			if didMount then
-				task.defer(didMount, element.props)
+				task.spawn(didMount, element.props)
 			end
 		end
 		
@@ -1460,12 +1556,17 @@ local function createReconciler(): Types.Reconciler
 		
 		mountByElementKind[ElementKinds.SiblingCluster] = function(virtualNode)
 			local providedHost = virtualNode._hostContext
+			local lastProvidedInstance: Instance? = nil
+			local consumedInstances: {[number]: Instance?} = {}
+
+			local parentSiblingClusterCache = providedHost.siblingClusterCache
+			if parentSiblingClusterCache then
+				lastProvidedInstance = parentSiblingClusterCache.lastProvidedInstance
+			end
+
 			local siblingClusterCache = {
-				currentSiblingIdx = 1,
-				providedInstanceHostSet = {},
-				idxToProvidedInstanceHost = {},
-				idxToConsumedInstanceHost = {},
-				lastProvidedInstance = nil,
+				lastProvidedInstance = lastProvidedInstance,
+				lastUpdateConsumedInstances = consumedInstances,
 			}
 			local siblingHost = createHost(
 				providedHost.instance,
@@ -1473,12 +1574,13 @@ local function createReconciler(): Types.Reconciler
 				providedHost.providers,
 				siblingClusterCache
 			)
-			virtualNode._hostContext = siblingHost
+			virtualNode._siblingHost = siblingHost
 			local elements = virtualNode._currentElement.elements
 			local siblings = table.create(#elements)
 
 			for i = 1, #elements do
-				siblingClusterCache.currentSiblingIdx = i
+				lastProvidedInstance = siblingClusterCache.lastProvidedInstance
+				consumedInstances[i] = lastProvidedInstance
 				local node = mountVirtualNode(
 					elements[i],
 					siblingHost
@@ -1489,6 +1591,11 @@ local function createReconciler(): Types.Reconciler
 			end
 			
 			virtualNode._siblings = siblings
+
+			if parentSiblingClusterCache and lastProvidedInstance then
+				parentSiblingClusterCache.lastProvidedInstance = lastProvidedInstance
+			end
+
 			return virtualNode
 		end
 
@@ -1521,66 +1628,6 @@ local function createReconciler(): Types.Reconciler
 	end
 	
 	do
-		--[[
-			This utility should thoroughly clear cached values within a sibling cluster, if one
-			exists in the host context.
-
-			The issue with behavior consistency in sibling clusters is in situations like the
-			following example:
-
-				1. Mount a pract tree with a Pract.combine element, containing a Pract.stamp and
-				Pract.decorate component.
-
-					When mounted, the stamp element will stamp a template instance, and via the
-					sibling cluster cache, the decorate element will decorate the previously stamped
-					instance in this cluster.
-				
-				2. Update the pract tree with a similar Pract.combine element—the only difference
-				being that the stamp element has changed its template!
-
-					When updated, the first stamp element in this sibling cluster must be replaced--
-					that is, it should be unmounted then mounted again with the new template.
-
-					The issue here is that the next Pract.decorate element in this cluster DEPENDS
-					on the host created via the previous stamp element! This means it must be
-					replaced (unmounted then mounted again) as well! This is handled in the sibling
-					cluster update code.
-			
-			The current solution to this issue uses a cache within the host context itself; this
-			implementation is a little obscure and prone to memory leaks if it isn't designed with
-			airtight code. In addition, adding element types to Pract would require taking sibling
-			cluster behavior in the future. Unit tests can alleviate some of these issues, but
-			the combinatorial possibilities/proliferation of element types could make this hard to
-			thoroughly unit test with newly implemented element types. In addition, the sibling
-			cluster needs to propogate into certain nested hosts or elements using the same host.
-		]]
-		local function unmountSiblingClusterHost(
-			hostContext: Types.HostContext,
-			instance: Instance
-		)
-			local siblingClusterCache = hostContext.siblingClusterCache
-			if siblingClusterCache then
-				local currentSiblingIdx = siblingClusterCache.currentSiblingIdx
-				local idxToProvidedInstanceHost = siblingClusterCache.idxToProvidedInstanceHost
-				local idxToConsumedInstanceHost = siblingClusterCache.idxToConsumedInstanceHost
-				local providedInstanceHostSet = siblingClusterCache.providedInstanceHostSet
-				providedInstanceHostSet[instance] = nil
-				idxToProvidedInstanceHost[currentSiblingIdx] = nil
-				idxToConsumedInstanceHost[currentSiblingIdx] = nil
-				if siblingClusterCache.lastProvidedInstance == instance then
-					local maxIdx, maxInst = next(idxToProvidedInstanceHost)
-					for idx, inst in pairs(idxToProvidedInstanceHost) do
-						if idx > maxIdx then
-							maxIdx = idx
-							maxInst = inst
-						end
-					end
-
-					siblingClusterCache.lastProvidedInstance = maxInst
-				end
-			end
-		end
-
 		local unmountByElementKind = {} :: {
 			[Types.Symbol]: (virtualNode: Types.VirtualNode) -> ()
 		}
@@ -1594,14 +1641,12 @@ local function createReconciler(): Types.Reconciler
 			unmountDecorationProps(virtualNode, true)
 			unmountChildren(virtualNode)
 			local instance = virtualNode._instance
-			unmountSiblingClusterHost(virtualNode._hostContext, instance)
 			instance:Destroy()
 		end
 		unmountByElementKind[ElementKinds.Stamp] = function(virtualNode)
 			unmountDecorationProps(virtualNode, true)
 			unmountChildren(virtualNode)
 			local instance = virtualNode._instance
-			unmountSiblingClusterHost(virtualNode._hostContext, instance)
 			instance:Destroy()
 		end
 		unmountByElementKind[ElementKinds.Portal] = function(virtualNode)
@@ -1619,7 +1664,7 @@ local function createReconciler(): Types.Reconciler
 			
 			local willUnmount = closure.willUnmount
 			if willUnmount then
-				willUnmount(saveElement.props)
+				task.spawn(willUnmount, saveElement.props)
 			end
 			
 			unmountVirtualNode(virtualNode._child)
@@ -1638,11 +1683,8 @@ local function createReconciler(): Types.Reconciler
 			unmountVirtualNode(virtualNode._child)
 		end
 		unmountByElementKind[ElementKinds.SiblingCluster] = function(virtualNode)
-			local siblingHost = virtualNode._hostContext
-			local siblingClusterCache = siblingHost.siblingClusterCache :: Types.SiblingClusterCache
 			local siblings = virtualNode._siblings
 			for i = 1, #siblings do
-				siblingClusterCache.currentSiblingIdx = i
 				unmountVirtualNode(siblings[i])
 			end
 		end

--- a/Pract/init.lua
+++ b/Pract/init.lua
@@ -5,7 +5,7 @@
 -- https://ambers-careware.github.io/pract/
 
 local Pract = {}
-Pract._VERSION = '0.9.10'
+Pract._VERSION = '0.9.11'
 
 local Types = require(script.Types)
 local PractGlobalSystems = require(script.PractGlobalSystems)

--- a/docs/advanced/combine.md
+++ b/docs/advanced/combine.md
@@ -61,4 +61,98 @@ end)
 
 `Pract.combine` can make it really easy to make your UI cross-platform compatible, without having to re-write cross platform input code every time you create a new button! Simply create a decorator component like our `HoverInput` above, and combine it with a platform-agnostic visual component!
 
+## Host Propogation
+
+The order in which you combine elements matters when determining the _host context_ of each element being combined.
+
+For example, you can combine the element `Pract.create("Frame")` with `Pract.decorate({Size = UDim2.fromOffset(20, 20)})` to both create and decorate the same instance. As in the Hoverinput example, this can be used to make "decorative" components that add functionality to another pre-created element. The Pract reconciler will automatically match _decorative_ elements with _instancing_ element's hosts. This means that the order in which you combine elements matters.
+
+As a rule of thumb:
+    - Place `Pract.stamp` and `Pract.create("ClassName")` elements earlier in the combined tuple.
+    - Place `Pract.decorate` and `Pract.index` elements later in the combined tuple.
+    - If a component returns a `Pract.stamp`/`Pract.create("ClassName")` element, place the
+    `Pract.create(Component)` expression earlier in the combined tuple. Otherwise, place it later.
+
+## A Caveat On Combine Order
+
+When a `Pract.combine` element is updated, the order of combined elements matter when determining which elements are unmounted/remounted!
+Here's a simple example that highlights the behavior:
+
+```lua
+local function ValueDecorator(props: {value: string})
+    return Pract.decorate({
+        Value = props.value,
+        [Pract.OnMountWithHost] = function()
+            print(value .. " mounted!")
+        end,
+        [Pract.OnUnmountWithHost] = function()
+            print(value .. " mounted!")
+        end,
+    })
+end
+
+local tree = Pract.mount(
+    Pract.combine(
+        Pract.create("StringValue", workspace),
+        Pract.create(ValueDecorator, {value = "Foo"}),
+        Pract.create(ValueDecorator, {value = "Bar"})
+    ),
+    "MyStringValue"
+)
+```
+
+This should create a StringValue named "MyStringValue" in workspace, with a value finally set to "Bar".
+The output should show that "Foo" mounted and then "Bar" mounted:
+
+```txt
+Foo mounted!
+Bar mounted!
+```
+
+If we update our tree with our "Foo" element removed, we will see the positionally-dependent behavior of `combine` in action:
+
+```lua
+Pract.update(
+    tree,
+    Pract.combine(
+        Pract.create("StringValue", workspace),
+        Pract.create(ValueDecorator, {value = "Bar"})
+    )
+)
+```
+
+Our output shows that both "Foo" and "Bar" were unmounted before re-mounting "Bar"; this is because "Bar" was moved from the third position on our `combine` tuple to the second position. Pract recognizes that the component type at each position has changed, and will re-mount these components instead of performing a regular update:
+
+```txt
+Foo unmounted!
+Bar unmounted!
+Bar mounted!
+```
+
+If your combine expression contains a conditional list of elements, make sure that all of your conditional elements (i.e. elements that are only _sometimes_ in a component's combine tuple) are placed `_last_` in the combine tuple where possible.
+
+Example:
+```lua
+--!strict
+local Pract = require(game.ReplicatedStorage.Pract)
+local StampingComponent = require(game.ReplicatedStorage.StampingComponent)
+local RecoloringComponent = require(game.ReplicatedStorage.RecoloringComponent)
+local RepositioningComponent = require(game.ReplicatedStorage.RepositioningComponent)
+
+local function MyComponent(props: {reposition: boolean})
+    local elements: {Pract.Element} = {}
+
+    table.insert(elements, Pract.create(StampingComponent, {}))
+    table.insert(elements, Pract.create(RecoloringComponent, {}))
+
+    -- Because this element is conditional, we want it to be placed LAST in our array of elements!
+    if props.reposition then
+     table.insert(elements, Pract.create(RepositioningComponent, {}))
+    end
+
+    -- Convert our array of elements to a tuple of combined elements
+    return Pract.combine(unpack(elements))
+end
+```
+
 #### Up next: [Using Pract.Children in Components](./children)

--- a/docs/api/elements.md
+++ b/docs/api/elements.md
@@ -91,7 +91,9 @@ Pract.combine(
 ): Pract.Element
 ```
 
-See: [State](../advanced/combine) for more detailed examples using `Pract.combine`
+> Warning: The order of elements in a `Pract.combine` tuple matters! See the [Combining Elements](../advanced/combine) for more information!
+
+See: [Combining Elements](../advanced/combine) for more detailed examples using `Pract.combine`
 
 Returns an element which instructs pract to mount multiple elements with the same host context. A good use case for this is having components dedicated to user input mounted together with components, which decorate the same instance. With `Pract.combine`, user input components can be re-used, while visual components can be more specialized.
 

--- a/docs/api/symbols.md
+++ b/docs/api/symbols.md
@@ -101,7 +101,7 @@ end
 ```
 ## Pract.OnMountWithHost
 
-Can be used as a key in the props of an Instance-modifying element. Will fire the listener when the element is mounted in a defered thread. The value in props should be typed as `(rbx: any, props: any, setOnCleanup: (cleanupCallback: () -> ()) -> ()) -> ()`
+Can be used as a key in the props of an Instance-modifying element. Will fire the listener when the element is mounted, in a spawned thread. The value in props should be typed as `(rbx: any, props: any, setOnCleanup: (cleanupCallback: () -> ()) -> ()) -> ()`
 
 Example:
 ```lua
@@ -143,7 +143,7 @@ end
 
 ## Pract.OnUpdateWithHost
 
-Can be used as a key in the props of an Instance-modifying element. Will fire the listener when the element is updated in a defered thread. The value in props should be typed as `(rbx: any, props: any) -> ()`
+Can be used as a key in the props of an Instance-modifying element. Will fire the listener when the element is updated or mounted, in a spawned thread. The value in props should be typed as `(rbx: any, props: any) -> ()`
 
 Example:
 ```lua
@@ -159,7 +159,7 @@ end
 
 ## Pract.OnUnmountWithHost
 
-Can be used as a key in the props of an Instance-modifying element. Will fire the listener when the element is unmounted in a defered thread. The value in props should be typed as `(rbx: any) -> ()`
+Can be used as a key in the props of an Instance-modifying element. Will fire the listener when the element is unmounted, in a spawned thread. The value in props should be typed as `(rbx: any) -> ()`
 
 ```lua
 type Props = {}


### PR DESCRIPTION
This PR refactors the cache solution used to unmount and re-mount components based on position when updating a `Pract.combine` component.

In addition to this, this PR documents and unit tests this behavior in greater detail.